### PR TITLE
Add support for different datatypes for the partition column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage.xml
 *.mo
 *.pot
 
+# IDEA stuff
+.idea
+
 # Django stuff:
 *.log
 local_settings.py


### PR DESCRIPTION
Hi gglanzani,

I would like to suggest a pull request. Instead of only having string-types for the partition columns, the datatype can be optionally supplied. This will force checks on the type.

Cheers, Fokko